### PR TITLE
feat(ci): add GitLab CI/CD pipeline configuration and deployment scripts

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,111 @@
+stages:
+  - lint
+  - test
+  - build
+  - security
+  - deploy
+
+variables:
+  NODE_ENV: test
+  NPM_CONFIG_CACHE: .npm
+  NEXT_TELEMETRY_DISABLED: "1"
+
+default:
+  image: node:20
+  cache:
+    key: ${CI_COMMIT_REF_SLUG}
+    paths:
+      - .npm
+  before_script:
+    - npm config set cache "${CI_PROJECT_DIR}/.npm"
+
+frontend-lint:
+  stage: lint
+  script:
+    - npm ci --prefer-offline --no-audit --prefix frontend
+    - npm run lint --prefix frontend
+  artifacts:
+    when: on_failure
+    paths:
+      - frontend/.next
+
+backend-test:
+  stage: test
+  script:
+    - npm ci --prefer-offline --no-audit --prefix backend
+    - MONGO_URI=${MONGO_URI:-mongodb://localhost:27017/estatewise-ci} npm test --prefix backend -- --runInBand --passWithNoTests
+
+frontend-test:
+  stage: test
+  script:
+    - npm ci --prefer-offline --no-audit --prefix frontend
+    - npm run test --prefix frontend -- --runInBand --passWithNoTests
+
+backend-build:
+  stage: build
+  needs:
+    - backend-test
+  script:
+    - npm ci --prefer-offline --no-audit --prefix backend
+    - npm run build --prefix backend
+
+frontend-build:
+  stage: build
+  needs:
+    - frontend-test
+  script:
+    - npm ci --prefer-offline --no-audit --prefix frontend
+    - npm run build --prefix frontend
+
+security-audit:
+  stage: security
+  needs:
+    - backend-build
+    - frontend-build
+  script:
+    - npm ci --prefer-offline --prefix backend
+    - npm ci --prefer-offline --prefix frontend
+    - npm audit --prefix backend --audit-level=high
+    - npm audit --prefix frontend --audit-level=high
+
+deploy-blue-green:
+  stage: deploy
+  needs:
+    - security-audit
+  rules:
+    - if: $DEPLOY_STRATEGY == "blue-green" && $CI_COMMIT_BRANCH == "main"
+      when: manual
+    - when: never
+  script:
+    - bash gitlab/deploy.sh
+  environment:
+    name: production
+    action: start
+
+deploy-canary:
+  stage: deploy
+  needs:
+    - security-audit
+  rules:
+    - if: $DEPLOY_STRATEGY == "canary" && $CI_COMMIT_BRANCH == "main"
+      when: manual
+    - when: never
+  script:
+    - bash gitlab/deploy.sh
+  environment:
+    name: production
+    action: start
+
+deploy-rolling:
+  stage: deploy
+  needs:
+    - security-audit
+  rules:
+    - if: $DEPLOY_STRATEGY == "rolling" && $CI_COMMIT_BRANCH == "main"
+      when: manual
+    - when: never
+  script:
+    - bash gitlab/deploy.sh
+  environment:
+    name: production
+    action: start

--- a/DEPLOYMENTS.md
+++ b/DEPLOYMENTS.md
@@ -24,6 +24,9 @@ In addition, the monorepo already supports **Vercel** deployments for the fronte
 
 It also supports advanced deployment strategies like **Blue-Green** and **Canary** deployments for zero-downtime releases and safe progressive delivery.
 
+> [!NEW]
+> GitLab CI/CD is now supported out of the box via `.gitlab-ci.yml`, mirroring the Jenkins flow and wiring directly into the Kubernetes blue/green and canary scripts through `gitlab/deploy.sh`.
+
 ---
 
 ## Table of Contents

--- a/DEVOPS.md
+++ b/DEVOPS.md
@@ -111,6 +111,26 @@ flowchart TB
 
 ---
 
+## GitLab CI/CD (self-managed or SaaS)
+
+GitLab pipelines mirror the Jenkins flow with first-class support for blue/green, canary, and rolling rollouts.
+
+- **Pipeline file**: `.gitlab-ci.yml`
+- **Deploy helper**: `gitlab/deploy.sh` (wraps the existing Kubernetes scripts)
+- **Stages**: lint → test → build → security (npm audit) → deploy (manual)
+- **Defaults**: Node 20 runner image, project-local `.npm` cache, `NEXT_TELEMETRY_DISABLED=1`
+- **Key variables**:
+  - `DEPLOY_STRATEGY`: `blue-green`, `canary`, or `rolling`
+  - `IMAGE_TAG`: container image to deploy
+  - `SERVICE_NAME`: target workload (default `backend`)
+  - `NAMESPACE`: Kubernetes namespace (default `estatewise`)
+  - Optional toggles: `AUTO_SWITCH`, `SMOKE_TEST`, `SCALE_DOWN_OLD`, `CANARY_STAGES`, `STAGE_DURATION`, `AUTO_PROMOTE`, `ENABLE_METRICS`, `CANARY_REPLICAS_START`, `STABLE_REPLICAS`
+- **Kube auth**: Prefer GitLab’s Kubernetes agent or protected CI variables for `KUBECONFIG`. No Dockerfile changes are required.
+
+> Tip: Protect deploy jobs to `main` and require approvals; pair with the `deployment-control/` dashboard for visibility.
+
+---
+
 ## Deployment Strategies
 
 EstateWise supports three primary deployment strategies, each suited for different scenarios.

--- a/README.md
+++ b/README.md
@@ -703,6 +703,8 @@ See [DEVOPS.md](DEVOPS.md) for detailed guides and [kubernetes/scripts/](kuberne
 - **Azure Pipelines** – Container build/update pipeline for Container Apps
 - **GCP Cloud Build** – Docker build + Cloud Run deploy in a single step
 - **Travis CI** – Alternative CI provider (see [TRAVIS_CI.md](TRAVIS_CI.md))
+- **GitLab CI** – Support for GitLab-hosted repos
+- **Deployment Control Dashboard** – View deployment status, history, rollbacks across clouds, and control canary/blue-green deployments (see [deployment-control/](deployment-control/))
 
 ### Deployment Architecture Overview
 

--- a/deployment-control/README.md
+++ b/deployment-control/README.md
@@ -1,0 +1,38 @@
+# Deployment Control Dashboard
+
+UI and lightweight API to run EstateWise blue/green, canary, rolling, and scaling operations without the CLI. It wraps the existing Kubernetes scripts in `kubernetes/scripts/` and surfaces them through a web dashboard and JSON endpoints.
+
+## Features
+
+- Blue/green and canary launches with custom images, stages, and safety toggles
+- Rolling restarts and ad-hoc scaling for any deployment variant (stable, blue, green, canary)
+- Live job feed with logs and exit codes
+- Cluster snapshot (deployments + services) via `kubectl`
+- Ships as a single Express server that also serves the static dashboard UI
+
+## Quick start
+
+```bash
+cd deployment-control
+npm install
+npm run dev     # http://localhost:4100
+```
+
+The server uses your current `kubectl` context. Set `KUBECTL=/custom/bin/kubectl` if you need a different binary. Default namespace is `estatewise`; override from the top-right namespace field in the UI.
+
+## API
+
+All endpoints are relative to the server root (default `http://localhost:4100`).
+
+- `POST /api/deploy/blue-green` – Body: `image` (required), `serviceName`, `namespace`, `autoSwitch`, `smokeTest`, `scaleDownOld`
+- `POST /api/deploy/canary` – Body: `image` (required), `serviceName`, `namespace`, `canaryStages`, `stageDuration`, `autoPromote`, `enableMetrics`, `canaryReplicasStart`, `stableReplicas`
+- `POST /api/deploy/rolling` – Body: `serviceName`, `namespace`, `kubectl` (optional override)
+- `POST /api/ops/scale` – Body: `serviceName`, `namespace`, `replicas` (number), `variant` (`blue`, `green`, `canary`, or empty for stable), `kubectl` (optional override)
+- `GET /api/jobs` and `GET /api/jobs/:id` – Job history and output
+- `GET /api/cluster/summary?namespace=estatewise` – Snapshot of deployments/services via `kubectl`
+
+## Notes
+
+- The dashboard keeps only the last 500 log lines per job in memory. Persist results elsewhere if you need long-term history.
+- Long-running deploys stream back to the job feed; refresh or use the **Refresh** button to update.
+- The server runs commands from the repo root so relative scripts and manifests resolve correctly.

--- a/deployment-control/package.json
+++ b/deployment-control/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "estatewise-deployment-control",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Dashboard UI and API to operate EstateWise blue-green, canary, and rolling deployments without the CLI.",
+  "scripts": {
+    "dev": "ts-node-dev --respawn --transpile-only src/server.ts",
+    "build": "tsc",
+    "start": "node dist/server.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.19.2"
+  },
+  "devDependencies": {
+    "@types/cors": "^2.8.17",
+    "@types/express": "^4.17.21",
+    "@types/node": "^22.7.4",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.6.3"
+  }
+}

--- a/deployment-control/public/app.js
+++ b/deployment-control/public/app.js
@@ -1,0 +1,306 @@
+const summaryEl = document.getElementById('summary');
+const summaryStatus = document.getElementById('summaryStatus');
+const namespaceInput = document.getElementById('namespace');
+const jobsEl = document.getElementById('jobs');
+const toastEl = document.getElementById('toast');
+
+const escapeHtml = (value) =>
+  String(value || '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+
+const showToast = (message) => {
+  toastEl.textContent = message;
+  toastEl.classList.add('show');
+  setTimeout(() => toastEl.classList.remove('show'), 2500);
+};
+
+const statusBadge = (status) => {
+  switch (status) {
+    case 'succeeded':
+      return 'badge badge--success';
+    case 'failed':
+      return 'badge badge--danger';
+    case 'running':
+      return 'badge badge--warn';
+    default:
+      return 'badge badge--outline';
+  }
+};
+
+const formatTime = (value) => {
+  if (!value) {
+    return '—';
+  }
+
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? '—' : date.toLocaleTimeString();
+};
+
+const renderSummary = (summary) => {
+  if (!summary || !summary.deployments || !summary.deployments.length) {
+    summaryEl.innerHTML =
+      '<p class="muted">No deployments reported in this namespace.</p>';
+    return;
+  }
+
+  const cards = summary.deployments
+    .map((deploy) => {
+      const healthy =
+        deploy.readyReplicas === deploy.desiredReplicas &&
+        deploy.desiredReplicas > 0;
+      const badge = healthy
+        ? '<span class="badge badge--success">healthy</span>'
+        : '<span class="badge badge--warn">needs attention</span>';
+
+      return `
+        <div class="summary-card">
+          <div class="summary-meta">
+            <span>${escapeHtml(deploy.name)}</span>
+            ${badge}
+          </div>
+          <h3>${escapeHtml(deploy.readyReplicas)} / ${escapeHtml(
+        deploy.desiredReplicas
+      )} ready</h3>
+          <p class="meta">Images: ${
+            deploy.images && deploy.images.length
+              ? escapeHtml(deploy.images.join(', '))
+              : 'n/a'
+          }</p>
+        </div>
+      `;
+    })
+    .join('');
+
+  summaryEl.innerHTML = cards;
+};
+
+const fetchSummary = async () => {
+  const namespace = namespaceInput.value || 'estatewise';
+  summaryStatus.textContent = `Loading ${namespace}…`;
+  try {
+    const res = await fetch(
+      `/api/cluster/summary?namespace=${encodeURIComponent(namespace)}`
+    );
+    if (!res.ok) {
+      throw new Error(await res.text());
+    }
+    const data = await res.json();
+    summaryStatus.textContent = `Updated ${new Date(
+      data.timestamp
+    ).toLocaleTimeString()} · ${data.namespace}`;
+    renderSummary(data);
+  } catch (error) {
+    summaryStatus.textContent = 'Unable to read cluster';
+    showToast('Failed to load cluster summary. Check kubectl context.');
+    summaryEl.innerHTML =
+      '<p class="muted">Cluster data unavailable. Verify kubectl context.</p>';
+    // eslint-disable-next-line no-console
+    console.error(error);
+  }
+};
+
+const renderJobs = (jobs) => {
+  if (!jobs || !jobs.length) {
+    jobsEl.innerHTML =
+      '<p class="muted">No jobs yet. Kick off a deployment to see activity.</p>';
+    return;
+  }
+
+  jobsEl.innerHTML = '';
+
+  jobs.forEach((job) => {
+    const jobEl = document.createElement('div');
+    jobEl.className = 'job';
+
+    const header = document.createElement('div');
+    header.className = 'job__header';
+
+    const title = document.createElement('div');
+    title.innerHTML = `<strong>${escapeHtml(
+      job.description
+    )}</strong><div class="meta">${escapeHtml(job.command)}</div>`;
+
+    const badge = document.createElement('span');
+    badge.className = statusBadge(job.status);
+    badge.textContent = job.status;
+
+    header.appendChild(title);
+    header.appendChild(badge);
+
+    const meta = document.createElement('div');
+    meta.className = 'job__meta';
+    meta.innerHTML = `
+      <span>Started: ${escapeHtml(formatTime(job.startedAt))}</span>
+      <span>Finished: ${escapeHtml(formatTime(job.finishedAt))}</span>
+      <span>Exit: ${job.exitCode === null || job.exitCode === undefined ? '—' : escapeHtml(job.exitCode)}</span>
+    `;
+
+    const params =
+      job.parameters && Object.keys(job.parameters).length
+        ? `<div class="meta">Params: ${escapeHtml(
+            JSON.stringify(job.parameters)
+          )}</div>`
+        : '';
+
+    const logs = document.createElement('pre');
+    logs.className = 'job__logs';
+    const output =
+      job.output && job.output.length
+        ? job.output.join('\n').trim()
+        : 'Waiting for output…';
+    logs.textContent = output;
+
+    jobEl.appendChild(header);
+    jobEl.appendChild(meta);
+    if (params) {
+      const paramsEl = document.createElement('div');
+      paramsEl.className = 'meta';
+      paramsEl.textContent = `Params: ${JSON.stringify(job.parameters)}`;
+      jobEl.appendChild(paramsEl);
+    }
+    jobEl.appendChild(logs);
+    jobsEl.appendChild(jobEl);
+  });
+};
+
+const fetchJobs = async () => {
+  try {
+    const res = await fetch('/api/jobs');
+    if (!res.ok) {
+      throw new Error(await res.text());
+    }
+
+    const data = await res.json();
+    renderJobs(data.jobs || []);
+  } catch (error) {
+    showToast('Could not load job feed.');
+    // eslint-disable-next-line no-console
+    console.error(error);
+  }
+};
+
+const submitJson = async (url, body) => {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    throw new Error(await res.text());
+  }
+
+  return res.json();
+};
+
+document.getElementById('blueGreenForm').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const form = e.target;
+  const formData = new FormData(form);
+  const payload = {
+    image: formData.get('image'),
+    serviceName: formData.get('serviceName') || 'backend',
+    namespace: formData.get('namespace') || namespaceInput.value || 'estatewise',
+    autoSwitch: formData.get('autoSwitch') === 'on',
+    smokeTest: formData.get('smokeTest') === 'on',
+    scaleDownOld: formData.get('scaleDownOld') === 'on',
+  };
+
+  try {
+    await submitJson('/api/deploy/blue-green', payload);
+    showToast('Blue/Green deployment kicked off.');
+    fetchJobs();
+  } catch (error) {
+    showToast('Failed to start Blue/Green.');
+    // eslint-disable-next-line no-console
+    console.error(error);
+  }
+});
+
+document.getElementById('canaryForm').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const formData = new FormData(e.target);
+  const payload = {
+    image: formData.get('image'),
+    serviceName: formData.get('serviceName') || 'backend',
+    namespace: formData.get('namespace') || namespaceInput.value || 'estatewise',
+    canaryStages: formData.get('canaryStages') || '10,25,50,75,100',
+    stageDuration: Number(formData.get('stageDuration') || 120),
+    autoPromote: formData.get('autoPromote') === 'on',
+    enableMetrics: formData.get('enableMetrics') === 'on',
+    canaryReplicasStart: Number(formData.get('canaryReplicasStart') || 1),
+    stableReplicas: Number(formData.get('stableReplicas') || 2),
+  };
+
+  try {
+    await submitJson('/api/deploy/canary', payload);
+    showToast('Canary deployment started.');
+    fetchJobs();
+  } catch (error) {
+    showToast('Failed to start canary deployment.');
+    // eslint-disable-next-line no-console
+    console.error(error);
+  }
+});
+
+document.getElementById('rollingForm').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const formData = new FormData(e.target);
+  const payload = {
+    serviceName: formData.get('serviceName') || 'backend',
+    namespace: formData.get('namespace') || namespaceInput.value || 'estatewise',
+  };
+
+  try {
+    await submitJson('/api/deploy/rolling', payload);
+    showToast('Rolling restart kicked off.');
+    fetchJobs();
+  } catch (error) {
+    showToast('Rolling restart failed to start.');
+    // eslint-disable-next-line no-console
+    console.error(error);
+  }
+});
+
+document.getElementById('scaleForm').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const formData = new FormData(e.target);
+  const replicas = Number(formData.get('replicas'));
+  if (Number.isNaN(replicas)) {
+    showToast('Replicas must be a number.');
+    return;
+  }
+
+  const payload = {
+    serviceName: formData.get('serviceName') || 'backend',
+    namespace: namespaceInput.value || 'estatewise',
+    replicas,
+    variant: formData.get('variant') || undefined,
+  };
+
+  try {
+    await submitJson('/api/ops/scale', payload);
+    showToast('Scaling request sent.');
+    fetchJobs();
+  } catch (error) {
+    showToast('Failed to scale deployment.');
+    // eslint-disable-next-line no-console
+    console.error(error);
+  }
+});
+
+document
+  .getElementById('refreshSummary')
+  .addEventListener('click', fetchSummary);
+document
+  .getElementById('refreshSummarySecondary')
+  .addEventListener('click', fetchSummary);
+document.getElementById('refreshJobs').addEventListener('click', fetchJobs);
+
+fetchJobs();
+fetchSummary();
+setInterval(fetchJobs, 6000);

--- a/deployment-control/public/index.html
+++ b/deployment-control/public/index.html
@@ -1,0 +1,201 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Deployment Control | EstateWise</title>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Sora:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div class="background-glow"></div>
+  <header class="hero">
+    <div class="hero__content">
+      <p class="eyebrow">EstateWise Delivery</p>
+      <h1>Deployment Control</h1>
+      <p class="lede">Operate blue/green, canary, and rolling updates without touching the CLI. Track live jobs, inspect cluster state, and ship with confidence.</p>
+      <div class="hero__actions">
+        <button id="refreshSummary" class="ghost">Refresh cluster</button>
+        <span class="meta" id="summaryStatus">Awaiting data…</span>
+      </div>
+    </div>
+    <div class="hero__pill">
+      <div>
+        <p class="meta">Namespace</p>
+        <input id="namespace" type="text" value="estatewise" aria-label="Namespace" />
+      </div>
+      <div>
+        <p class="meta">Kube Context</p>
+        <span class="badge badge--outline">uses local kubectl</span>
+      </div>
+    </div>
+  </header>
+
+  <main class="layout">
+    <section class="panel">
+      <div class="panel__header">
+        <div>
+          <p class="eyebrow">Live cluster</p>
+          <h2>Deployment health</h2>
+        </div>
+        <div class="panel__actions">
+          <button id="refreshSummarySecondary" class="ghost ghost--small">Refresh</button>
+        </div>
+      </div>
+      <div id="summary" class="summary-grid">
+        <p class="muted">No data yet. Click refresh to fetch cluster state.</p>
+      </div>
+    </section>
+
+    <section class="panel">
+      <div class="panel__header">
+        <div>
+          <p class="eyebrow">Blue / Green</p>
+          <h2>Swap traffic safely</h2>
+        </div>
+        <div class="pill pill--soft">Zero downtime</div>
+      </div>
+      <form id="blueGreenForm" class="form">
+        <label>
+          <span>Container image</span>
+          <input name="image" type="text" placeholder="ghcr.io/your-org/estatewise-app-backend:v1.2.3" required>
+        </label>
+        <div class="grid-2">
+          <label>
+            <span>Service name</span>
+            <input name="serviceName" type="text" value="backend">
+          </label>
+          <label>
+            <span>Namespace</span>
+            <input name="namespace" type="text" value="estatewise">
+          </label>
+        </div>
+        <div class="toggles">
+          <label class="toggle">
+            <input type="checkbox" name="autoSwitch">
+            <span>Auto switch traffic</span>
+          </label>
+          <label class="toggle">
+            <input type="checkbox" name="smokeTest">
+            <span>Run smoke test</span>
+          </label>
+          <label class="toggle">
+            <input type="checkbox" name="scaleDownOld">
+            <span>Scale down old slot</span>
+          </label>
+        </div>
+        <button type="submit" class="primary">Launch Blue/Green</button>
+      </form>
+    </section>
+
+    <section class="panel">
+      <div class="panel__header">
+        <div>
+          <p class="eyebrow">Canary</p>
+          <h2>Progressive delivery</h2>
+        </div>
+        <div class="pill pill--soft pill--accent">Guarded rollout</div>
+      </div>
+      <form id="canaryForm" class="form">
+        <label>
+          <span>Container image</span>
+          <input name="image" type="text" placeholder="ghcr.io/your-org/estatewise-app-backend:v1.2.3" required>
+        </label>
+        <div class="grid-2">
+          <label>
+            <span>Service name</span>
+            <input name="serviceName" type="text" value="backend">
+          </label>
+          <label>
+            <span>Namespace</span>
+            <input name="namespace" type="text" value="estatewise">
+          </label>
+        </div>
+        <div class="grid-2">
+          <label>
+            <span>Canary stages (%)</span>
+            <input name="canaryStages" type="text" value="10,25,50,75,100">
+          </label>
+          <label>
+            <span>Stage duration (s)</span>
+            <input name="stageDuration" type="number" min="10" value="120">
+          </label>
+        </div>
+        <div class="grid-2">
+          <label>
+            <span>Stable replicas</span>
+            <input name="stableReplicas" type="number" min="1" value="2">
+          </label>
+          <label>
+            <span>Canary start replicas</span>
+            <input name="canaryReplicasStart" type="number" min="1" value="1">
+          </label>
+        </div>
+        <div class="toggles">
+          <label class="toggle">
+            <input type="checkbox" name="autoPromote">
+            <span>Auto promote stages</span>
+          </label>
+          <label class="toggle">
+            <input type="checkbox" name="enableMetrics">
+            <span>Enforce metrics gate</span>
+          </label>
+        </div>
+        <button type="submit" class="primary">Launch Canary</button>
+      </form>
+    </section>
+
+    <section class="panel">
+      <div class="panel__header">
+        <div>
+          <p class="eyebrow">Ops</p>
+          <h2>Quick controls</h2>
+        </div>
+        <div class="pill pill--outline">Kubernetes native</div>
+      </div>
+      <div class="ops-grid">
+        <div class="op-card">
+          <div>
+            <p class="meta">Rolling restart</p>
+            <h3>Restart deployment</h3>
+          </div>
+          <form id="rollingForm" class="inline-form">
+            <input name="serviceName" type="text" value="backend" aria-label="Service name">
+            <input name="namespace" type="text" value="estatewise" aria-label="Namespace">
+            <button type="submit" class="ghost ghost--tight">Restart</button>
+          </form>
+        </div>
+        <div class="op-card">
+          <div>
+            <p class="meta">Scale</p>
+            <h3>Adjust replicas</h3>
+          </div>
+          <form id="scaleForm" class="inline-form">
+            <input name="serviceName" type="text" value="backend" aria-label="Service name">
+            <input name="replicas" type="number" min="0" value="3" aria-label="Replicas">
+            <input name="variant" type="text" placeholder="stable / blue / green / canary" aria-label="Variant">
+            <button type="submit" class="ghost ghost--tight">Scale</button>
+          </form>
+        </div>
+      </div>
+    </section>
+
+    <section class="panel panel--wide">
+      <div class="panel__header">
+        <div>
+          <p class="eyebrow">Activity</p>
+          <h2>Job feed</h2>
+        </div>
+        <div class="panel__actions">
+          <button id="refreshJobs" class="ghost ghost--small">Refresh</button>
+        </div>
+      </div>
+      <div id="jobs" class="jobs"></div>
+    </section>
+  </main>
+
+  <div id="toast" class="toast" role="status" aria-live="polite"></div>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/deployment-control/public/styles.css
+++ b/deployment-control/public/styles.css
@@ -1,0 +1,412 @@
+:root {
+  --bg: #0d1829;
+  --bg-2: #0f243d;
+  --panel: #111f33;
+  --border: rgba(255, 255, 255, 0.08);
+  --accent: #ffb703;
+  --accent-2: #14cba8;
+  --muted: #a0aec0;
+  --text: #e9edf5;
+  --danger: #ff6b6b;
+  --success: #5cf2c7;
+  --warning: #ffd166;
+  --shadow: 0 18px 60px rgba(0, 0, 0, 0.35);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Space Grotesk', 'Sora', 'Inter', system-ui, -apple-system, sans-serif;
+  background: radial-gradient(120% 120% at 20% 20%, #1b2b46 0%, #0b1526 50%, #050b14 100%);
+  color: var(--text);
+  min-height: 100vh;
+  padding: 0 24px 48px;
+}
+
+.background-glow {
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(60% 40% at 80% 20%, rgba(255, 183, 3, 0.12), transparent),
+    radial-gradient(45% 50% at 15% 60%, rgba(20, 203, 168, 0.16), transparent);
+  filter: blur(50px);
+  z-index: 0;
+  pointer-events: none;
+}
+
+header.hero {
+  position: relative;
+  z-index: 1;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 48px 0 12px;
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.hero__content h1 {
+  margin: 8px 0;
+  font-size: 42px;
+  letter-spacing: -0.02em;
+}
+
+.hero__content .lede {
+  margin: 8px 0 18px;
+  color: var(--muted);
+  max-width: 640px;
+  line-height: 1.5;
+}
+
+.hero__actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.hero__pill {
+  background: linear-gradient(135deg, rgba(255, 183, 3, 0.08), rgba(20, 203, 168, 0.08));
+  border: 1px solid var(--border);
+  padding: 18px 20px;
+  border-radius: 18px;
+  min-width: 220px;
+  box-shadow: var(--shadow);
+  display: grid;
+  gap: 12px;
+}
+
+.hero__pill input {
+  width: 100%;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 10px 12px;
+  border-radius: 10px;
+}
+
+.layout {
+  position: relative;
+  z-index: 1;
+  max-width: 1200px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 18px;
+}
+
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 18px;
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(6px);
+}
+
+.panel--wide {
+  grid-column: 1 / -1;
+}
+
+.panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+.panel__header h2 {
+  margin: 4px 0 0;
+  letter-spacing: -0.01em;
+}
+
+.panel__actions {
+  display: flex;
+  gap: 8px;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 12px;
+  color: var(--muted);
+  margin: 0;
+}
+
+.lede {
+  margin: 0;
+}
+
+.meta {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.pill {
+  padding: 6px 10px;
+  border-radius: 999px;
+  font-size: 13px;
+  border: 1px solid transparent;
+}
+
+.pill--soft {
+  background: rgba(255, 183, 3, 0.12);
+  color: #ffd166;
+  border-color: rgba(255, 183, 3, 0.2);
+}
+
+.pill--accent {
+  background: rgba(20, 203, 168, 0.14);
+  color: var(--accent-2);
+  border-color: rgba(20, 203, 168, 0.2);
+}
+
+.pill--outline {
+  border-color: var(--border);
+  color: var(--muted);
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 12px;
+}
+
+.summary-card {
+  border: 1px solid var(--border);
+  padding: 12px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.summary-card h3 {
+  margin: 4px 0 6px;
+  font-size: 17px;
+}
+
+.summary-meta {
+  display: flex;
+  justify-content: space-between;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 8px;
+  border-radius: 12px;
+  font-size: 12px;
+  text-transform: capitalize;
+}
+
+.badge--outline {
+  border: 1px solid var(--border);
+  color: var(--muted);
+}
+
+.badge--success {
+  background: rgba(92, 242, 199, 0.12);
+  color: var(--success);
+}
+
+.badge--danger {
+  background: rgba(255, 107, 107, 0.12);
+  color: var(--danger);
+}
+
+.badge--warn {
+  background: rgba(255, 209, 102, 0.12);
+  color: var(--warning);
+}
+
+.form {
+  display: grid;
+  gap: 12px;
+}
+
+.grid-2 {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 10px;
+}
+
+label span {
+  display: block;
+  color: var(--muted);
+  font-size: 13px;
+  margin-bottom: 6px;
+}
+
+input {
+  width: 100%;
+  padding: 11px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--text);
+}
+
+.toggles {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 10px;
+}
+
+.toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid var(--border);
+  padding: 10px;
+  border-radius: 12px;
+}
+
+button {
+  border: none;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: transform 0.1s ease, box-shadow 0.15s ease;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+button:active {
+  transform: translateY(1px);
+}
+
+.primary {
+  background: linear-gradient(120deg, #ffb703, #f7931a);
+  color: #0b1526;
+  padding: 12px 14px;
+  box-shadow: 0 12px 30px rgba(255, 183, 3, 0.25);
+}
+
+.ghost {
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text);
+  border: 1px solid var(--border);
+  padding: 10px 12px;
+}
+
+.ghost--tight {
+  padding: 8px 12px;
+}
+
+.ghost--small {
+  padding: 6px 10px;
+  font-size: 13px;
+}
+
+.ops-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 12px;
+}
+
+.op-card {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 12px;
+  background: rgba(255, 255, 255, 0.02);
+  display: grid;
+  gap: 10px;
+}
+
+.op-card h3 {
+  margin: 4px 0;
+}
+
+.inline-form {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 8px;
+  align-items: center;
+}
+
+.jobs {
+  display: grid;
+  gap: 12px;
+}
+
+.job {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 12px;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.job__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+}
+
+.job__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  color: var(--muted);
+  font-size: 13px;
+  margin: 6px 0;
+}
+
+.job__logs {
+  background: #0b1526;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 8px;
+  margin-top: 8px;
+  max-height: 180px;
+  overflow: auto;
+  font-family: 'Sora', 'SFMono-Regular', Consolas, Menlo, monospace;
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.muted {
+  color: var(--muted);
+}
+
+.toast {
+  position: fixed;
+  right: 20px;
+  bottom: 20px;
+  background: #0b1526;
+  color: var(--text);
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+  opacity: 0;
+  transform: translateY(10px);
+  transition: all 0.2s ease;
+  z-index: 10;
+}
+
+.toast.show {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media (max-width: 720px) {
+  header.hero {
+    flex-direction: column;
+  }
+
+  .hero__pill {
+    width: 100%;
+  }
+
+  .layout {
+    grid-template-columns: 1fr;
+  }
+}

--- a/deployment-control/src/jobRunner.ts
+++ b/deployment-control/src/jobRunner.ts
@@ -1,0 +1,122 @@
+import { spawn } from 'child_process';
+import { randomUUID } from 'crypto';
+import path from 'path';
+import { JobRecord, JobResponse, JobType } from './types';
+
+const jobs = new Map<string, JobRecord>();
+const MAX_LOG_LINES = 500;
+
+interface RunJobOptions {
+  type: JobType;
+  description: string;
+  command: string;
+  args?: string[];
+  cwd: string;
+  env?: NodeJS.ProcessEnv;
+  parameters?: Record<string, unknown>;
+}
+
+const newId = (): string => {
+  if (typeof randomUUID === 'function') {
+    return randomUUID();
+  }
+
+  return `job-${Date.now()}-${Math.floor(Math.random() * 10000)}`;
+};
+
+const toResponse = (record: JobRecord): JobResponse => ({
+  ...record,
+  createdAt: record.createdAt.toISOString(),
+  startedAt: record.startedAt ? record.startedAt.toISOString() : undefined,
+  finishedAt: record.finishedAt ? record.finishedAt.toISOString() : undefined,
+});
+
+const appendOutput = (record: JobRecord, chunk: string): void => {
+  const normalized = chunk.replace(/\r\n/g, '\n');
+  const lines = normalized.split('\n');
+  record.output.push(...lines);
+
+  if (record.output.length > MAX_LOG_LINES) {
+    record.output.splice(0, record.output.length - MAX_LOG_LINES);
+  }
+};
+
+export const runJob = (options: RunJobOptions): JobResponse => {
+  const id = newId();
+  const args = options.args ?? [];
+  const job: JobRecord = {
+    id,
+    type: options.type,
+    description: options.description,
+    command: `${options.command} ${args.join(' ')}`.trim(),
+    status: 'running',
+    createdAt: new Date(),
+    startedAt: new Date(),
+    output: [],
+    parameters: options.parameters,
+    exitCode: null,
+  };
+
+  jobs.set(id, job);
+
+  const child = spawn(options.command, args, {
+    cwd: path.resolve(options.cwd),
+    env: { ...process.env, ...options.env },
+  });
+
+  child.stdout.on('data', (data: Buffer) => {
+    const current = jobs.get(id);
+    if (!current) {
+      return;
+    }
+
+    appendOutput(current, data.toString());
+  });
+
+  child.stderr.on('data', (data: Buffer) => {
+    const current = jobs.get(id);
+    if (!current) {
+      return;
+    }
+
+    appendOutput(current, data.toString());
+  });
+
+  child.on('error', (error: Error) => {
+    const current = jobs.get(id);
+    if (!current) {
+      return;
+    }
+
+    current.error = error.message;
+    current.status = 'failed';
+    current.exitCode = null;
+    current.finishedAt = new Date();
+  });
+
+  child.on('close', (code: number | null) => {
+    const current = jobs.get(id);
+    if (!current) {
+      return;
+    }
+
+    current.exitCode = code;
+    current.finishedAt = new Date();
+    current.status = code === 0 ? 'succeeded' : 'failed';
+  });
+
+  return toResponse(job);
+};
+
+export const listJobs = (limit = 50): JobResponse[] => {
+  const values = Array.from(jobs.values()).sort(
+    (a, b) => b.createdAt.getTime() - a.createdAt.getTime()
+  );
+
+  return values.slice(0, limit).map(toResponse);
+};
+
+export const findJob = (id: string): JobResponse | undefined => {
+  const record = jobs.get(id);
+  return record ? toResponse(record) : undefined;
+};

--- a/deployment-control/src/kubectl.ts
+++ b/deployment-control/src/kubectl.ts
@@ -1,0 +1,92 @@
+import { spawn } from 'child_process';
+import path from 'path';
+import {
+  ClusterDeploymentSummary,
+  ClusterServiceSummary,
+  ClusterSummary,
+} from './types';
+
+export const repoRoot = path.resolve(__dirname, '..', '..');
+export const scriptsDir = path.join(repoRoot, 'kubernetes', 'scripts');
+
+const kubectlBinary = (): string => process.env.KUBECTL || 'kubectl';
+
+export const runKubectl = async (
+  args: string[],
+  namespace?: string
+): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const finalArgs = [...args];
+    if (namespace) {
+      finalArgs.push('-n', namespace);
+    }
+
+    const child = spawn(kubectlBinary(), finalArgs, {
+      env: process.env,
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.on('data', (data: Buffer) => {
+      stdout += data.toString();
+    });
+
+    child.stderr.on('data', (data: Buffer) => {
+      stderr += data.toString();
+    });
+
+    child.on('error', (error: Error) => {
+      reject(error);
+    });
+
+    child.on('close', (code: number | null) => {
+      if (code === 0) {
+        resolve(stdout.trim());
+      } else {
+        reject(new Error(stderr.trim() || `kubectl exited with code ${code}`));
+      }
+    });
+  });
+
+export const getClusterSummary = async (
+  namespace = 'estatewise'
+): Promise<ClusterSummary> => {
+  const deploymentsJson = await runKubectl(
+    ['get', 'deployments', '-o', 'json'],
+    namespace
+  );
+  const servicesJson = await runKubectl(
+    ['get', 'service', '-o', 'json'],
+    namespace
+  );
+
+  const deploymentsRaw = JSON.parse(deploymentsJson);
+  const servicesRaw = JSON.parse(servicesJson);
+
+  const deployments: ClusterDeploymentSummary[] =
+    deploymentsRaw.items?.map((item: any) => ({
+      name: item?.metadata?.name ?? 'unknown',
+      readyReplicas: Number(item?.status?.readyReplicas ?? 0),
+      availableReplicas: Number(item?.status?.availableReplicas ?? 0),
+      desiredReplicas: Number(item?.spec?.replicas ?? 0),
+      images:
+        item?.spec?.template?.spec?.containers
+          ?.map((container: any) => container?.image)
+          .filter(Boolean) ?? [],
+    })) ?? [];
+
+  const services: ClusterServiceSummary[] =
+    servicesRaw.items?.map((svc: any) => ({
+      name: svc?.metadata?.name ?? 'unknown',
+      type: svc?.spec?.type ?? 'ClusterIP',
+      clusterIP: svc?.spec?.clusterIP ?? 'n/a',
+    })) ?? [];
+
+  return {
+    namespace,
+    deployments,
+    services,
+    timestamp: new Date().toISOString(),
+  };
+};

--- a/deployment-control/src/server.ts
+++ b/deployment-control/src/server.ts
@@ -1,0 +1,196 @@
+import cors from 'cors';
+import express, { Request, Response } from 'express';
+import path from 'path';
+import { findJob, listJobs, runJob } from './jobRunner';
+import { getClusterSummary, repoRoot, scriptsDir } from './kubectl';
+
+const app = express();
+const port = Number(process.env.PORT || 4100);
+
+app.use(cors());
+app.use(express.json({ limit: '1mb' }));
+
+const staticDir = path.join(repoRoot, 'deployment-control', 'public');
+app.use(express.static(staticDir));
+
+app.get('/api/health', (_req: Request, res: Response) => {
+  res.json({ status: 'ok', uptime: process.uptime() });
+});
+
+app.get('/api/jobs', (req: Request, res: Response) => {
+  const limit = req.query.limit ? Number(req.query.limit) : 50;
+  res.json({ jobs: listJobs(limit) });
+});
+
+app.get('/api/jobs/:id', (req: Request, res: Response) => {
+  const job = findJob(req.params.id);
+  if (!job) {
+    res.status(404).json({ error: 'Job not found' });
+    return;
+  }
+
+  res.json(job);
+});
+
+app.post('/api/deploy/blue-green', (req: Request, res: Response) => {
+  const {
+    serviceName = 'backend',
+    image,
+    namespace = 'estatewise',
+    autoSwitch = false,
+    smokeTest = false,
+    scaleDownOld = false,
+  } = req.body || {};
+
+  if (!image) {
+    res.status(400).json({ error: 'image is required' });
+    return;
+  }
+
+  const script = path.join(scriptsDir, 'blue-green-deploy.sh');
+  const job = runJob({
+    type: 'blue-green',
+    description: `Blue/Green: ${serviceName} -> ${image}`,
+    command: script,
+    args: [serviceName, image],
+    cwd: repoRoot,
+    env: {
+      NAMESPACE: namespace,
+      AUTO_SWITCH: autoSwitch ? 'true' : 'false',
+      SMOKE_TEST: smokeTest ? 'true' : 'false',
+      SCALE_DOWN_OLD: scaleDownOld ? 'true' : 'false',
+    },
+    parameters: { serviceName, image, namespace, autoSwitch, smokeTest, scaleDownOld },
+  });
+
+  res.status(202).json(job);
+});
+
+app.post('/api/deploy/canary', (req: Request, res: Response) => {
+  const {
+    serviceName = 'backend',
+    image,
+    namespace = 'estatewise',
+    canaryStages = '10,25,50,75,100',
+    stageDuration = 120,
+    autoPromote = false,
+    enableMetrics = false,
+    canaryReplicasStart = 1,
+    stableReplicas = 2,
+  } = req.body || {};
+
+  if (!image) {
+    res.status(400).json({ error: 'image is required' });
+    return;
+  }
+
+  const script = path.join(scriptsDir, 'canary-deploy.sh');
+  const job = runJob({
+    type: 'canary',
+    description: `Canary: ${serviceName} -> ${image} (${canaryStages}%)`,
+    command: script,
+    args: [serviceName, image],
+    cwd: repoRoot,
+    env: {
+      NAMESPACE: namespace,
+      CANARY_STAGES: String(canaryStages),
+      STAGE_DURATION: String(stageDuration),
+      AUTO_PROMOTE: autoPromote ? 'true' : 'false',
+      ENABLE_METRICS: enableMetrics ? 'true' : 'false',
+      CANARY_REPLICAS_START: String(canaryReplicasStart),
+      STABLE_REPLICAS: String(stableReplicas),
+    },
+    parameters: {
+      serviceName,
+      image,
+      namespace,
+      canaryStages,
+      stageDuration,
+      autoPromote,
+      enableMetrics,
+      canaryReplicasStart,
+      stableReplicas,
+    },
+  });
+
+  res.status(202).json(job);
+});
+
+app.post('/api/deploy/rolling', (req: Request, res: Response) => {
+  const {
+    serviceName = 'backend',
+    namespace = 'estatewise',
+    kubectl = process.env.KUBECTL || 'kubectl',
+  } = req.body || {};
+
+  const command = `${kubectl} rollout restart deployment/estatewise-${serviceName} -n ${namespace} && ${kubectl} rollout status deployment/estatewise-${serviceName} -n ${namespace}`;
+
+  const job = runJob({
+    type: 'rolling',
+    description: `Rolling restart: ${serviceName}`,
+    command: 'bash',
+    args: ['-lc', command],
+    cwd: repoRoot,
+    env: { KUBECTL: kubectl },
+    parameters: { serviceName, namespace, kubectl },
+  });
+
+  res.status(202).json(job);
+});
+
+app.post('/api/ops/scale', (req: Request, res: Response) => {
+  const {
+    serviceName = 'backend',
+    namespace = 'estatewise',
+    replicas,
+    variant,
+    kubectl = process.env.KUBECTL || 'kubectl',
+  } = req.body || {};
+
+  if (replicas === undefined || replicas === null) {
+    res.status(400).json({ error: 'replicas is required' });
+    return;
+  }
+
+  const deploymentName = variant
+    ? `estatewise-${serviceName}-${variant}`
+    : `estatewise-${serviceName}`;
+
+  const command = `${kubectl} scale deployment/${deploymentName} --replicas=${replicas} -n ${namespace}`;
+
+  const job = runJob({
+    type: 'scale',
+    description: `Scale ${deploymentName} -> ${replicas}`,
+    command: 'bash',
+    args: ['-lc', command],
+    cwd: repoRoot,
+    env: { KUBECTL: kubectl },
+    parameters: { serviceName, namespace, replicas, variant },
+  });
+
+  res.status(202).json(job);
+});
+
+app.get('/api/cluster/summary', async (req: Request, res: Response) => {
+  const namespace = (req.query.namespace as string) || 'estatewise';
+  try {
+    const summary = await getClusterSummary(namespace);
+    res.json(summary);
+  } catch (error: unknown) {
+    res.status(500).json({
+      error:
+        error instanceof Error
+          ? error.message
+          : 'Failed to fetch cluster summary',
+    });
+  }
+});
+
+app.get('*', (_req: Request, res: Response) => {
+  res.sendFile(path.join(staticDir, 'index.html'));
+});
+
+app.listen(port, () => {
+  // eslint-disable-next-line no-console
+  console.log(`Deployment Control running on http://localhost:${port}`);
+});

--- a/deployment-control/src/types.ts
+++ b/deployment-control/src/types.ts
@@ -1,0 +1,59 @@
+export type JobType =
+  | 'blue-green'
+  | 'canary'
+  | 'rolling'
+  | 'scale'
+  | 'cluster-status';
+
+export type JobStatus = 'queued' | 'running' | 'succeeded' | 'failed';
+
+export interface JobRecord {
+  id: string;
+  type: JobType;
+  description: string;
+  command: string;
+  status: JobStatus;
+  createdAt: Date;
+  startedAt?: Date;
+  finishedAt?: Date;
+  output: string[];
+  exitCode?: number | null;
+  parameters?: Record<string, unknown>;
+  error?: string;
+}
+
+export interface JobResponse {
+  id: string;
+  type: JobType;
+  description: string;
+  command: string;
+  status: JobStatus;
+  createdAt: string;
+  startedAt?: string;
+  finishedAt?: string;
+  output: string[];
+  exitCode?: number | null;
+  parameters?: Record<string, unknown>;
+  error?: string;
+}
+
+export interface ClusterDeploymentSummary {
+  name: string;
+  readyReplicas: number;
+  availableReplicas: number;
+  desiredReplicas: number;
+  images: string[];
+}
+
+export interface ClusterServiceSummary {
+  name: string;
+  type: string;
+  clusterIP: string;
+}
+
+export interface ClusterSummary {
+  namespace: string;
+  deployments: ClusterDeploymentSummary[];
+  services: ClusterServiceSummary[];
+  timestamp: string;
+}

--- a/deployment-control/tsconfig.json
+++ b/deployment-control/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "rootDir": "src",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "node",
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}

--- a/gitlab/README.md
+++ b/gitlab/README.md
@@ -1,0 +1,50 @@
+# GitLab CI/CD for EstateWise
+
+This repo now ships with a GitLab pipeline (`.gitlab-ci.yml`) and a deploy helper (`gitlab/deploy.sh`) that wrap the existing Kubernetes scripts for blue/green, canary, and rolling deployments.
+
+## Pipeline stages
+
+1. **lint** – Frontend lint (`npm run lint --prefix frontend`).
+2. **test** – Backend and frontend Jest runs (serial to reduce flakiness).
+3. **build** – TypeScript build for backend and Next.js build for frontend.
+4. **security** – `npm audit --audit-level=high` on backend and frontend.
+5. **deploy** – Manual, strategy-specific deploy jobs.
+
+> The pipeline uses `node:20` and caches `~/.npm` in project-local `.npm`.
+
+## Required CI variables
+
+Set these in GitLab project or group settings:
+
+- `KUBECONFIG` – Base64-encoded kubeconfig or inject via `K8S_SERVICE_ACCOUNT` integration.
+- `IMAGE_TAG` – Container image (e.g., `ghcr.io/your-org/estatewise-app-backend:v1.2.3`).
+- `SERVICE_NAME` – Kubernetes service name (default `backend`).
+- `NAMESPACE` – Target namespace (default `estatewise`).
+- `DEPLOY_STRATEGY` – `blue-green`, `canary`, or `rolling` (set per environment or manual job variable).
+- Optional toggles:
+  - Blue/Green: `AUTO_SWITCH`, `SMOKE_TEST`, `SCALE_DOWN_OLD` (all default `false`).
+  - Canary: `CANARY_STAGES` (e.g., `10,25,50,75,100`), `STAGE_DURATION`, `AUTO_PROMOTE`, `ENABLE_METRICS`, `CANARY_REPLICAS_START`, `STABLE_REPLICAS`.
+
+## Deploy helper
+
+`gitlab/deploy.sh` invokes:
+
+- `kubernetes/scripts/blue-green-deploy.sh` (blue/green)
+- `kubernetes/scripts/canary-deploy.sh` (canary)
+- `kubectl rollout restart` (rolling)
+
+It respects the environment variables above and runs from the repo root, so manifest-relative paths continue to work.
+
+## Usage
+
+1. Push to a branch; the pipeline runs lint, tests, build, and security.
+2. Merge to `main`.
+3. Trigger the desired deploy job (manual) with `DEPLOY_STRATEGY` and `IMAGE_TAG` set.
+4. Monitor rollout via pipeline logs or `deployment-control/` dashboard.
+
+## Prod readiness tips
+
+- Use GitLab protected variables and protected branches/tags for production deploys.
+- Add a GitLab Kubernetes cluster integration to avoid storing kubeconfig as a file.
+- For canary metrics, set `ENABLE_METRICS=true` and extend `check_canary_metrics` to query Prometheus.
+- Enable merge request approvals and status checks on `lint`, `test`, and `security-audit` jobs.

--- a/gitlab/deploy.sh
+++ b/gitlab/deploy.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# GitLab deploy helper that wraps existing EstateWise deployment scripts.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPTS_DIR="${ROOT_DIR}/kubernetes/scripts"
+
+STRATEGY="${DEPLOY_STRATEGY:-}"
+SERVICE_NAME="${SERVICE_NAME:-backend}"
+IMAGE_TAG="${IMAGE_TAG:-}"
+NAMESPACE="${NAMESPACE:-estatewise}"
+KUBECTL_BIN="${KUBECTL:-kubectl}"
+
+if [[ -z "${STRATEGY}" ]]; then
+  echo "DEPLOY_STRATEGY must be set to blue-green, canary, or rolling" >&2
+  exit 1
+fi
+
+case "${STRATEGY}" in
+  blue-green)
+    if [[ -z "${IMAGE_TAG}" ]]; then
+      echo "IMAGE_TAG is required for blue-green deployments" >&2
+      exit 1
+    fi
+
+    AUTO_SWITCH="${AUTO_SWITCH:-false}"
+    SMOKE_TEST="${SMOKE_TEST:-false}"
+    SCALE_DOWN_OLD="${SCALE_DOWN_OLD:-false}"
+
+    echo "Starting blue/green for ${SERVICE_NAME} -> ${IMAGE_TAG} in ${NAMESPACE}"
+    NAMESPACE="${NAMESPACE}" \
+      AUTO_SWITCH="${AUTO_SWITCH}" \
+      SMOKE_TEST="${SMOKE_TEST}" \
+      SCALE_DOWN_OLD="${SCALE_DOWN_OLD}" \
+      "${SCRIPTS_DIR}/blue-green-deploy.sh" "${SERVICE_NAME}" "${IMAGE_TAG}"
+    ;;
+  canary)
+    if [[ -z "${IMAGE_TAG}" ]]; then
+      echo "IMAGE_TAG is required for canary deployments" >&2
+      exit 1
+    fi
+
+    CANARY_STAGES="${CANARY_STAGES:-10,25,50,75,100}"
+    STAGE_DURATION="${STAGE_DURATION:-120}"
+    AUTO_PROMOTE="${AUTO_PROMOTE:-false}"
+    ENABLE_METRICS="${ENABLE_METRICS:-false}"
+    CANARY_REPLICAS_START="${CANARY_REPLICAS_START:-1}"
+    STABLE_REPLICAS="${STABLE_REPLICAS:-2}"
+
+    echo "Starting canary for ${SERVICE_NAME} -> ${IMAGE_TAG} in ${NAMESPACE} (${CANARY_STAGES}%)"
+    NAMESPACE="${NAMESPACE}" \
+      CANARY_STAGES="${CANARY_STAGES}" \
+      STAGE_DURATION="${STAGE_DURATION}" \
+      AUTO_PROMOTE="${AUTO_PROMOTE}" \
+      ENABLE_METRICS="${ENABLE_METRICS}" \
+      CANARY_REPLICAS_START="${CANARY_REPLICAS_START}" \
+      STABLE_REPLICAS="${STABLE_REPLICAS}" \
+      "${SCRIPTS_DIR}/canary-deploy.sh" "${SERVICE_NAME}" "${IMAGE_TAG}"
+    ;;
+  rolling)
+    echo "Rolling restart for ${SERVICE_NAME} in ${NAMESPACE}"
+    ${KUBECTL_BIN} rollout restart "deployment/estatewise-${SERVICE_NAME}" -n "${NAMESPACE}"
+    ${KUBECTL_BIN} rollout status "deployment/estatewise-${SERVICE_NAME}" -n "${NAMESPACE}"
+    ;;
+  *)
+    echo "Unsupported DEPLOY_STRATEGY: ${STRATEGY}" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
This pull request introduces first-class support for GitLab CI/CD pipelines and adds a new "Deployment Control Dashboard" to the EstateWise monorepo. The changes enable automated and manual blue/green, canary, and rolling deployments using GitLab, and provide a web-based dashboard for operating and monitoring deployments without relying on the CLI. Documentation is updated to reflect these new capabilities.

**GitLab CI/CD Integration**
- Added `.gitlab-ci.yml` for out-of-the-box GitLab pipeline support, including lint, test, build, security audit, and manual deploy stages for blue/green, canary, and rolling strategies. The pipeline uses Node 20, local npm cache, and disables Next.js telemetry. It wires directly into the existing Kubernetes scripts via `gitlab/deploy.sh`.
- Documentation (`DEPLOYMENTS.md`, `DEVOPS.md`, `README.md`) updated to describe GitLab CI/CD setup, variables, and deployment strategies, mirroring the Jenkins workflow and highlighting integration points. [[1]](diffhunk://#diff-8e24dc9232b204a9cd599de0385ff77483468f4103851c93936595e4a691816aR27-R29) [[2]](diffhunk://#diff-68c96bc359ff4d9a18e92487cca8cb4f5eb9a40cc0b6b717ed6fe11e21373771R114-R133) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R706-R707)

**Deployment Control Dashboard**
- Added new `deployment-control/` package with a dashboard UI and API for blue/green, canary, rolling deployments, restarts, and scaling. The dashboard wraps Kubernetes scripts and exposes endpoints for deployment operations and cluster summaries. [[1]](diffhunk://#diff-9d640c0c9eed94cad75dda7acfeb41ed44437fd8c9dcd3ba50288f31134983deR1-R38) [[2]](diffhunk://#diff-b0deb5b3cfe0f10fad7dda40adad7257f82e70b7c2d09d864bf317ac9d81c18eR1-R22)
- Implemented frontend (`deployment-control/public/index.html`, `deployment-control/public/app.js`) for live cluster health, job feed, and forms to launch deployments and operations. [[1]](diffhunk://#diff-beac149176d4883f7742e8a2df52026cfa74fc6f6e2b537b7354763545b7149aR1-R201) [[2]](diffhunk://#diff-538033e3c1376e6d41f2d639c0ca84d5e163051623705fdfae1422560da32be4R1-R306)

These changes collectively streamline CI/CD and operations for EstateWise, making advanced deployment strategies accessible via both GitLab and a user-friendly dashboard.