### PR TITLE
docs(sre): add tip for EstateWise SRE practices in the guide

### DIFF
--- a/SRE.md
+++ b/SRE.md
@@ -1,5 +1,6 @@
 # Site Reliability Engineering (SRE) Guide
 
+> [!TIP]
 > **EstateWise** -- A real estate AI platform monorepo with full-spectrum SRE practices: SLOs, error budgets, multi-window burn-rate alerting, progressive delivery, multi-region failover, and deep agentic AI observability.
 
 This document is the single-pane reference for every reliability, observability, and operational concern in the EstateWise platform. It is intended for on-call engineers, SRE practitioners, platform leads, and anyone deploying or operating EstateWise services.


### PR DESCRIPTION
This pull request adds a tip box to the top of the `SRE.md` guide, highlighting EstateWise's comprehensive SRE practices for quick reference. No other changes were made.